### PR TITLE
Let certificates be handled by the server.

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -200,7 +200,6 @@ class Api
     ));
     curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($ch, CURLOPT_CAINFO, dirname(dirname(__FILE__)) . '/etc/cabundle.crt');
 
     curl_exec($ch);
 


### PR DESCRIPTION
The current certificate provided in this module is outdated. This will solve https://github.com/forwarder/belco-magento2/issues/5